### PR TITLE
Cleanup in dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,7 +17,6 @@ critic_config = t/.perlcriticrc
 [Test::EOL]
 [PodCoverageTests]
 [PodSyntaxTests]
-[ExecDir]
 [CheckChangeLog]
 [PkgVersion]
 [PodVersion]
@@ -30,5 +29,5 @@ Path::Class     = 0
 Task::Weaken    = 0
 Carp            = 0
 
-[Prereqs / BuildRequires]
+[Prereqs / TestRequires]
 Catalyst::Test = 0


### PR DESCRIPTION
- Catalyst::Test is a test requirement, not build
- ExecDir not needed
